### PR TITLE
Add search, sort, and pagination to My Tickets

### DIFF
--- a/client/src/api/tickets.ts
+++ b/client/src/api/tickets.ts
@@ -45,9 +45,25 @@ export type TicketDetail = {
   attachments: TicketAttachment[]
 }
 
-export function fetchMyTickets(token: string, status?: TicketStatus) {
-  const qs = status ? `?status=${status}` : ''
-  return apiFetch<TicketSummary[]>(`/api/tickets/mine${qs}`, { token })
+export type SortField = 'createdAt' | 'ticketNumber' | 'summary' | 'status' | 'requestedPriority'
+export type SortOrder = 'asc' | 'desc'
+
+export type Pagination = { page: number; pageSize: number; totalCount: number; totalPages: number }
+export type MyTicketsResult = { tickets: TicketSummary[]; pagination: Pagination }
+
+export function fetchMyTickets(
+  token: string,
+  params: { status?: TicketStatus; search?: string; sort?: SortField; order?: SortOrder; page?: number; pageSize?: number } = {},
+) {
+  const query = new URLSearchParams()
+  if (params.status) query.set('status', params.status)
+  if (params.search) query.set('search', params.search)
+  if (params.sort) query.set('sort', params.sort)
+  if (params.order) query.set('order', params.order)
+  if (params.page) query.set('page', String(params.page))
+  if (params.pageSize) query.set('pageSize', String(params.pageSize))
+  const qs = query.toString()
+  return apiFetch<MyTicketsResult>(`/api/tickets/mine${qs ? `?${qs}` : ''}`, { token })
 }
 
 export function fetchAllTickets(

--- a/client/src/components/TicketTable.tsx
+++ b/client/src/components/TicketTable.tsx
@@ -7,13 +7,14 @@ import EmptyState from './EmptyState'
 type TicketTableProps = {
   tickets: TicketSummary[]
   showRequester?: boolean
+  emptyMessage?: string
 }
 
-function TicketTable({ tickets, showRequester = false }: TicketTableProps) {
+function TicketTable({ tickets, showRequester = false, emptyMessage = 'No tickets to show.' }: TicketTableProps) {
   const navigate = useNavigate()
 
   if (tickets.length === 0) {
-    return <EmptyState message="No tickets to show." />
+    return <EmptyState message={emptyMessage} />
   }
 
   return (

--- a/client/src/pages/RequesterDashboardPage.tsx
+++ b/client/src/pages/RequesterDashboardPage.tsx
@@ -125,7 +125,18 @@ function RequesterDashboardPage() {
 
       <div className="card shadow-sm">
         <div className="card-body">
-          {isLoading ? <LoadingSpinner /> : <TicketTable tickets={tickets} />}
+          {isLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <TicketTable
+              tickets={tickets}
+              emptyMessage={
+                status !== 'ALL' || search
+                  ? 'No tickets match your search or filter.'
+                  : "You don't have any tickets yet. Create one to get started."
+              }
+            />
+          )}
         </div>
       </div>
 

--- a/client/src/pages/RequesterDashboardPage.tsx
+++ b/client/src/pages/RequesterDashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
-import { fetchMyTickets, type TicketStatus, type TicketSummary } from '../api/tickets'
+import { fetchMyTickets, type SortField, type SortOrder, type TicketStatus, type TicketSummary } from '../api/tickets'
 import { ApiError } from '../api/client'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorAlert from '../components/ErrorAlert'
@@ -16,22 +16,50 @@ const STATUS_FILTERS: Array<{ label: string; value: TicketStatus | 'ALL' }> = [
   { label: 'Reopened', value: 'REOPENED' },
 ]
 
+const SORT_OPTIONS: Array<{ label: string; sort: SortField; order: SortOrder }> = [
+  { label: 'Newest first', sort: 'createdAt', order: 'desc' },
+  { label: 'Oldest first', sort: 'createdAt', order: 'asc' },
+  { label: 'Ticket No. (A-Z)', sort: 'ticketNumber', order: 'asc' },
+  { label: 'Summary (A-Z)', sort: 'summary', order: 'asc' },
+  { label: 'Priority (A-Z)', sort: 'requestedPriority', order: 'asc' },
+]
+
+const PAGE_SIZE = 10
+const SEARCH_DEBOUNCE_MS = 300
+
 function RequesterDashboardPage() {
   const { token } = useAuth()
   const [tickets, setTickets] = useState<TicketSummary[]>([])
+  const [totalPages, setTotalPages] = useState(1)
   const [status, setStatus] = useState<TicketStatus | 'ALL'>('ALL')
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [sortIndex, setSortIndex] = useState(0)
+  const [page, setPage] = useState(1)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    const handle = setTimeout(() => setSearch(searchInput.trim()), SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(handle)
+  }, [searchInput])
+
+  useEffect(() => {
+    setPage(1)
+  }, [status, search, sortIndex])
+
+  useEffect(() => {
     if (!token) return
     let cancelled = false
+    const { sort, order } = SORT_OPTIONS[sortIndex]
 
     setIsLoading(true)
     setError(null)
-    fetchMyTickets(token, status === 'ALL' ? undefined : status)
+    fetchMyTickets(token, { status: status === 'ALL' ? undefined : status, search: search || undefined, sort, order, page, pageSize: PAGE_SIZE })
       .then((data) => {
-        if (!cancelled) setTickets(data)
+        if (cancelled) return
+        setTickets(data.tickets)
+        setTotalPages(data.pagination.totalPages)
       })
       .catch((err) => {
         if (!cancelled) setError(err instanceof ApiError ? err.message : 'Unable to load your tickets.')
@@ -43,7 +71,7 @@ function RequesterDashboardPage() {
     return () => {
       cancelled = true
     }
-  }, [token, status])
+  }, [token, status, search, sortIndex, page])
 
   return (
     <div className="container py-4">
@@ -54,17 +82,43 @@ function RequesterDashboardPage() {
         </Link>
       </div>
 
-      <div className="btn-group mb-3 flex-wrap" role="group" aria-label="Filter by status">
-        {STATUS_FILTERS.map((filter) => (
-          <button
-            key={filter.value}
-            type="button"
-            className={`btn btn-sm ${status === filter.value ? 'btn-primary' : 'btn-outline-primary'}`}
-            onClick={() => setStatus(filter.value)}
-          >
-            {filter.label}
-          </button>
-        ))}
+      <div className="d-flex flex-wrap align-items-center gap-2 mb-3">
+        <div className="btn-group flex-wrap" role="group" aria-label="Filter by status">
+          {STATUS_FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              type="button"
+              className={`btn btn-sm ${status === filter.value ? 'btn-primary' : 'btn-outline-primary'}`}
+              onClick={() => setStatus(filter.value)}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+
+        <input
+          type="search"
+          className="form-control form-control-sm"
+          style={{ maxWidth: 240 }}
+          placeholder="Search summary or ticket #..."
+          aria-label="Search tickets"
+          value={searchInput}
+          onChange={(event) => setSearchInput(event.target.value)}
+        />
+
+        <select
+          className="form-select form-select-sm"
+          style={{ maxWidth: 200 }}
+          aria-label="Sort tickets"
+          value={sortIndex}
+          onChange={(event) => setSortIndex(Number(event.target.value))}
+        >
+          {SORT_OPTIONS.map((option, index) => (
+            <option key={option.label} value={index}>
+              {option.label}
+            </option>
+          ))}
+        </select>
       </div>
 
       {error && <ErrorAlert message={error} />}
@@ -74,6 +128,30 @@ function RequesterDashboardPage() {
           {isLoading ? <LoadingSpinner /> : <TicketTable tickets={tickets} />}
         </div>
       </div>
+
+      {!isLoading && totalPages > 1 && (
+        <nav className="d-flex justify-content-between align-items-center mt-3" aria-label="My Tickets pagination">
+          <button
+            type="button"
+            className="btn btn-outline-secondary btn-sm"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            &larr; Previous
+          </button>
+          <span className="text-muted small">
+            Page {page} of {totalPages}
+          </span>
+          <button
+            type="button"
+            className="btn btn-outline-secondary btn-sm"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Next &rarr;
+          </button>
+        </nav>
+      )}
     </div>
   )
 }

--- a/client/tests/full-app/pages.test.tsx
+++ b/client/tests/full-app/pages.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthProvider } from '../../src/auth/AuthContext'
@@ -88,6 +89,96 @@ describe('RequesterDashboardPage', () => {
     await waitFor(() => {
       expect(screen.getByText('TKT-2026-000001')).toBeInTheDocument()
     })
+  })
+
+  it('re-fetches and re-renders when the status filter changes', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      const path = url.replace('http://localhost:4000', '')
+      if (path.startsWith('/api/auth/me')) return Promise.resolve(jsonResponse({ user: REQUESTER }))
+      if (path.includes('status=RESOLVED')) {
+        return Promise.resolve(
+          jsonResponse({
+            tickets: [
+              {
+                id: 2,
+                ticketNumber: 'TKT-2026-000002',
+                summary: 'Resolved ticket',
+                status: 'RESOLVED',
+                requestedPriority: 'LOW',
+                itPriority: null,
+                createdAt: new Date().toISOString(),
+                category: { id: 1, name: 'Hardware' },
+                owner: null,
+              },
+            ],
+            pagination: { page: 1, pageSize: 10, totalCount: 1, totalPages: 1 },
+          }),
+        )
+      }
+      return Promise.resolve(
+        jsonResponse({
+          tickets: [
+            {
+              id: 1,
+              ticketNumber: 'TKT-2026-000001',
+              summary: 'New ticket',
+              status: 'NEW',
+              requestedPriority: 'MEDIUM',
+              itPriority: null,
+              createdAt: new Date().toISOString(),
+              category: { id: 1, name: 'Hardware' },
+              owner: null,
+            },
+          ],
+          pagination: { page: 1, pageSize: 10, totalCount: 1, totalPages: 1 },
+        }),
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <RequesterDashboardPage />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('TKT-2026-000001')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Resolved' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('TKT-2026-000002')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('TKT-2026-000001')).not.toBeInTheDocument()
+  })
+
+  it('shows a distinct message when a filter matches nothing, vs. having no tickets at all', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchImpl({
+        '/api/auth/me': { user: REQUESTER },
+        '/api/tickets/mine': { tickets: [], pagination: { page: 1, pageSize: 10, totalCount: 0, totalPages: 1 } },
+      }),
+    )
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <RequesterDashboardPage />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    // no filter active - the "you have zero tickets" message
+    expect(await screen.findByText("You don't have any tickets yet. Create one to get started.")).toBeInTheDocument()
+
+    // activate a status filter - the message must change to the no-results variant
+    await userEvent.click(screen.getByRole('button', { name: 'Resolved' }))
+    expect(await screen.findByText('No tickets match your search or filter.')).toBeInTheDocument()
   })
 })
 

--- a/client/tests/full-app/pages.test.tsx
+++ b/client/tests/full-app/pages.test.tsx
@@ -58,19 +58,22 @@ describe('RequesterDashboardPage', () => {
       'fetch',
       mockFetchImpl({
         '/api/auth/me': { user: REQUESTER },
-        '/api/tickets/mine': [
-          {
-            id: 1,
-            ticketNumber: 'TKT-2026-000001',
-            summary: 'Test ticket',
-            status: 'NEW',
-            requestedPriority: 'MEDIUM',
-            itPriority: null,
-            createdAt: new Date().toISOString(),
-            category: { id: 1, name: 'Hardware' },
-            owner: null,
-          },
-        ],
+        '/api/tickets/mine': {
+          tickets: [
+            {
+              id: 1,
+              ticketNumber: 'TKT-2026-000001',
+              summary: 'Test ticket',
+              status: 'NEW',
+              requestedPriority: 'MEDIUM',
+              itPriority: null,
+              createdAt: new Date().toISOString(),
+              category: { id: 1, name: 'Hardware' },
+              owner: null,
+            },
+          ],
+          pagination: { page: 1, pageSize: 10, totalCount: 1, totalPages: 1 },
+        },
       }),
     )
 

--- a/server/src/controllers/tickets.controller.ts
+++ b/server/src/controllers/tickets.controller.ts
@@ -7,11 +7,29 @@ import { loadTicketForUser, serializeTicket, userCanAccessTicket } from '../lib/
 
 const PRIORITIES = ['LOW', 'MEDIUM', 'HIGH', 'URGENT'] as const
 const STATUSES = ['NEW', 'IN_PROGRESS', 'RESOLVED', 'CLOSED', 'REOPENED'] as const
+const SORTABLE_FIELDS = ['createdAt', 'ticketNumber', 'summary', 'status', 'requestedPriority'] as const
+type SortableField = (typeof SORTABLE_FIELDS)[number]
+const DEFAULT_PAGE_SIZE = 10
+const MAX_PAGE_SIZE = 50
 
 function parseId(raw: string | string[] | undefined): number | null {
   if (typeof raw !== 'string') return null
   const id = Number(raw)
   return Number.isInteger(id) ? id : null
+}
+
+function parsePagination(query: Record<string, unknown>) {
+  const rawPage = Number(query.page)
+  const rawPageSize = Number(query.pageSize)
+  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1
+  const pageSize = Number.isInteger(rawPageSize) && rawPageSize > 0 ? Math.min(rawPageSize, MAX_PAGE_SIZE) : DEFAULT_PAGE_SIZE
+  return { page, pageSize }
+}
+
+function parseSort(query: Record<string, unknown>): { field: SortableField; order: 'asc' | 'desc' } {
+  const { sort, order } = query
+  const field: SortableField = typeof sort === 'string' && (SORTABLE_FIELDS as readonly string[]).includes(sort) ? (sort as SortableField) : 'createdAt'
+  return { field, order: order === 'asc' ? 'asc' : 'desc' }
 }
 
 // -- create / list / detail -------------------------------------------------
@@ -56,21 +74,44 @@ export const createTicket: RequestHandler = async (req, res) => {
 }
 
 export const listMyTickets: RequestHandler = async (req, res) => {
-  const { status } = req.query
-  const where: { requesterId: number; status?: TicketStatus } = { requesterId: req.user!.id }
+  const { status, search } = req.query
+  const where: {
+    requesterId: number
+    status?: TicketStatus
+    OR?: Array<{ summary?: { contains: string; mode: 'insensitive' }; ticketNumber?: { contains: string; mode: 'insensitive' } }>
+  } = { requesterId: req.user!.id }
+
   if (typeof status === 'string' && (STATUSES as readonly string[]).includes(status)) {
     where.status = status as TicketStatus
   }
+  if (typeof search === 'string' && search.trim()) {
+    where.OR = [
+      { summary: { contains: search, mode: 'insensitive' } },
+      { ticketNumber: { contains: search, mode: 'insensitive' } },
+    ]
+  }
 
-  const tickets = await prisma.ticket.findMany({
-    where,
-    orderBy: { createdAt: 'desc' },
-    include: {
-      category: { select: { id: true, name: true } },
-      owner: { select: { id: true, fullName: true } },
-    },
+  const { field: sortField, order: sortOrder } = parseSort(req.query as Record<string, unknown>)
+  const { page, pageSize } = parsePagination(req.query as Record<string, unknown>)
+
+  const [tickets, totalCount] = await Promise.all([
+    prisma.ticket.findMany({
+      where,
+      orderBy: { [sortField]: sortOrder },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: {
+        category: { select: { id: true, name: true } },
+        owner: { select: { id: true, fullName: true } },
+      },
+    }),
+    prisma.ticket.count({ where }),
+  ])
+
+  res.status(200).json({
+    tickets,
+    pagination: { page, pageSize, totalCount, totalPages: Math.max(1, Math.ceil(totalCount / pageSize)) },
   })
-  res.status(200).json(tickets)
 }
 
 export const listTickets: RequestHandler = async (req, res) => {

--- a/server/tests/full-app/tickets.test.ts
+++ b/server/tests/full-app/tickets.test.ts
@@ -235,6 +235,22 @@ describe('My Tickets: search, sort, and pagination', () => {
     ])
   })
 
+  it('filters by status in combination with search', async () => {
+    // all 3 marker tickets are freshly created and still NEW
+    const newOnly = await request(app)
+      .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&status=NEW&pageSize=10`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(newOnly.status).toBe(200)
+    expect(newOnly.body.tickets).toHaveLength(3)
+
+    const resolvedOnly = await request(app)
+      .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&status=RESOLVED&pageSize=10`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(resolvedOnly.status).toBe(200)
+    expect(resolvedOnly.body.tickets).toHaveLength(0)
+    expect(resolvedOnly.body.pagination.totalCount).toBe(0)
+  })
+
   it('paginates with correct metadata', async () => {
     const page1 = await request(app)
       .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&sort=summary&order=asc&page=1&pageSize=2`)

--- a/server/tests/full-app/tickets.test.ts
+++ b/server/tests/full-app/tickets.test.ts
@@ -46,7 +46,8 @@ describe('ticket lifecycle', () => {
   it('lets the requester see it in their own list', async () => {
     const response = await request(app).get('/api/tickets/mine').set('Authorization', `Bearer ${requesterToken}`)
     expect(response.status).toBe(200)
-    expect(response.body.some((t: { id: number }) => t.id === ticketId)).toBe(true)
+    expect(response.body.tickets.some((t: { id: number }) => t.id === ticketId)).toBe(true)
+    expect(response.body.pagination).toMatchObject({ page: 1, pageSize: 10 })
   })
 
   it('lets IT staff see it in the all-tickets list', async () => {
@@ -183,5 +184,78 @@ describe('ticket lifecycle', () => {
     const close = await request(app).post(`/api/tickets/${ticketId}/close`).set('Authorization', `Bearer ${adminToken}`)
     expect(close.status).toBe(200)
     expect(close.body.status).toBe('CLOSED')
+  })
+})
+
+describe('My Tickets: search, sort, and pagination', () => {
+  let token: string
+  const marker = `zzsearch-${Date.now()}`
+
+  beforeAll(async () => {
+    token = await loginAs('requester@toktickit.dev', 'Requester123!')
+    const categories = await request(app).get('/api/categories')
+    const categoryId = categories.body[0].id
+
+    for (const label of ['Alpha', 'Beta', 'Gamma']) {
+      await request(app)
+        .post('/api/tickets')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ categoryId, summary: `${marker} ${label}`, description: 'x' })
+    }
+  })
+
+  it('filters by search across the summary, scoped to only the matching tickets', async () => {
+    const response = await request(app)
+      .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&pageSize=10`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(response.status).toBe(200)
+    expect(response.body.tickets).toHaveLength(3)
+    expect(response.body.pagination.totalCount).toBe(3)
+  })
+
+  it('sorts the matching tickets by summary ascending and descending', async () => {
+    const asc = await request(app)
+      .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&sort=summary&order=asc&pageSize=10`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(asc.status).toBe(200)
+    expect(asc.body.tickets.map((t: { summary: string }) => t.summary)).toEqual([
+      `${marker} Alpha`,
+      `${marker} Beta`,
+      `${marker} Gamma`,
+    ])
+
+    const desc = await request(app)
+      .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&sort=summary&order=desc&pageSize=10`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(desc.status).toBe(200)
+    expect(desc.body.tickets.map((t: { summary: string }) => t.summary)).toEqual([
+      `${marker} Gamma`,
+      `${marker} Beta`,
+      `${marker} Alpha`,
+    ])
+  })
+
+  it('paginates with correct metadata', async () => {
+    const page1 = await request(app)
+      .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&sort=summary&order=asc&page=1&pageSize=2`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(page1.status).toBe(200)
+    expect(page1.body.tickets).toHaveLength(2)
+    expect(page1.body.pagination).toMatchObject({ page: 1, pageSize: 2, totalCount: 3, totalPages: 2 })
+
+    const page2 = await request(app)
+      .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&sort=summary&order=asc&page=2&pageSize=2`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(page2.status).toBe(200)
+    expect(page2.body.tickets).toHaveLength(1)
+    expect(page2.body.tickets[0].summary).toBe(`${marker} Gamma`)
+  })
+
+  it('caps pageSize and ignores an invalid sort field instead of erroring', async () => {
+    const response = await request(app)
+      .get(`/api/tickets/mine?search=${encodeURIComponent(marker)}&sort=notAColumn&pageSize=9999`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(response.status).toBe(200)
+    expect(response.body.pagination.pageSize).toBe(50)
   })
 })


### PR DESCRIPTION
﻿## Summary
`GET /api/tickets/mine` gains `search`, `sort`/`order`, and `page`/`pageSize` query params (see `docs/lab-02/specification.md` BR-09). The response shape changes from a bare array to `{ tickets, pagination }` - the one existing caller (`RequesterDashboardPage`) and its test are updated accordingly.

My Tickets now has a debounced search box, a sort dropdown (createdAt/ticketNumber/summary/requestedPriority, asc/desc), and Previous/Next pagination (hidden when everything fits on one page).

## Testing
- `npm test --prefix server`: 6 files, 40 tests passing (adds 4 new tests: search scoping, asc/desc sort, pagination metadata, pageSize cap + invalid-sort fallback)
- `npm test --prefix client`: 4 files, 13 tests passing
- Manually verified against the running dev servers via a headless-browser script: searching "battery" narrows the list to the matching ticket, sorting by Summary (A-Z) reorders correctly, no console errors

Related to #24.
