### PR TITLE
Implement attachment upload validation and soft removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 # Vite / testing
 coverage/
 *.tsbuildinfo
+
+# Uploaded attachment files
+server/uploads/

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -20,7 +20,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export async function apiFetch<T>(path: string, options: RequestOptions = {}): Promise<T> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const isFormData = options.body instanceof FormData
+  const headers: Record<string, string> = {}
+  if (!isFormData) {
+    // omit Content-Type for FormData - the browser sets it (with the
+    // multipart boundary) automatically, which JSON.stringify below would break
+    headers['Content-Type'] = 'application/json'
+  }
   if (options.token) {
     headers.Authorization = `Bearer ${options.token}`
   }
@@ -28,7 +34,7 @@ export async function apiFetch<T>(path: string, options: RequestOptions = {}): P
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method: options.method ?? 'GET',
     headers,
-    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    body: isFormData ? (options.body as FormData) : options.body !== undefined ? JSON.stringify(options.body) : undefined,
   })
 
   const contentType = response.headers.get('content-type') ?? ''
@@ -40,4 +46,25 @@ export async function apiFetch<T>(path: string, options: RequestOptions = {}): P
   }
 
   return data as T
+}
+
+// For endpoints that return a raw file (e.g. attachment download) rather
+// than JSON - returns the Blob plus a best-effort filename from
+// Content-Disposition, or throws ApiError on failure using whatever error
+// body the server provided.
+export async function apiFetchBlob(path: string, token: string): Promise<{ blob: Blob; filename: string | null }> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  if (!response.ok) {
+    const contentType = response.headers.get('content-type') ?? ''
+    const data: unknown = contentType.includes('application/json') ? await response.json() : undefined
+    const message = isRecord(data) && typeof data.error === 'string' ? data.error : `Request failed with status ${response.status}`
+    throw new ApiError(response.status, message)
+  }
+
+  const disposition = response.headers.get('content-disposition') ?? ''
+  const match = /filename="?([^"]+)"?/.exec(disposition)
+  return { blob: await response.blob(), filename: match ? match[1] : null }
 }

--- a/client/src/api/tickets.ts
+++ b/client/src/api/tickets.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from './client'
+import { apiFetch, apiFetchBlob } from './client'
 import type { Role } from './auth'
 
 export type Priority = 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT'
@@ -20,7 +20,22 @@ export type TicketSummary = {
 export type Participant = { id: number; fullName: string; role: Role }
 export type TicketComment = { id: number; body: string; createdAt: string; author: Participant }
 export type TicketAction = { id: number; description: string; createdAt: string; updatedAt: string; author: Participant }
-export type TicketAttachment = { id: number; filename: string; url: string; createdAt: string; uploader: Participant }
+export type TicketAttachment = {
+  id: number
+  filename: string
+  mimeType: string
+  sizeBytes: number
+  isActive: boolean
+  createdAt: string
+  uploader: Participant
+  removedAt: string | null
+  removedReason: string | null
+  removedBy: Participant | null
+}
+
+export const ALLOWED_ATTACHMENT_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf']
+export const MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024
+export const MAX_ACTIVE_ATTACHMENTS = 5
 
 export type TicketDetail = {
   id: number
@@ -126,6 +141,24 @@ export function updateAction(token: string, id: number, actionId: number, descri
   return apiFetch<TicketAction>(`/api/tickets/${id}/actions/${actionId}`, { method: 'PATCH', token, body: { description } })
 }
 
-export function addAttachment(token: string, id: number, filename: string, url: string) {
-  return apiFetch<TicketAttachment>(`/api/tickets/${id}/attachments`, { method: 'POST', token, body: { filename, url } })
+export function addAttachment(token: string, id: number, file: File) {
+  const formData = new FormData()
+  formData.append('file', file)
+  return apiFetch<TicketAttachment>(`/api/tickets/${id}/attachments`, { method: 'POST', token, body: formData })
+}
+
+export async function downloadAttachment(token: string, attachmentId: number, fallbackFilename: string) {
+  const { blob, filename } = await apiFetchBlob(`/api/attachments/${attachmentId}/download`, token)
+  const objectUrl = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = objectUrl
+  link.download = filename ?? fallbackFilename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(objectUrl)
+}
+
+export function removeAttachment(token: string, attachmentId: number, reason: string) {
+  return apiFetch<TicketAttachment>(`/api/attachments/${attachmentId}`, { method: 'DELETE', token, body: { reason } })
 }

--- a/client/src/components/TicketDetailView.tsx
+++ b/client/src/components/TicketDetailView.tsx
@@ -16,6 +16,11 @@ import {
   addNote,
   addAction,
   addAttachment,
+  downloadAttachment,
+  removeAttachment,
+  ALLOWED_ATTACHMENT_TYPES,
+  MAX_ATTACHMENT_SIZE_BYTES,
+  MAX_ACTIVE_ATTACHMENTS,
   type TicketDetail,
   type Priority,
 } from '../api/tickets'
@@ -42,6 +47,12 @@ function formatDateTime(iso: string | null) {
   return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
 }
 
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 function Field({ label, value, colClass = 'col-md-3' }: { label: string; value: string; colClass?: string }) {
   return (
     <div className={colClass}>
@@ -64,8 +75,10 @@ function TicketDetailView({ backTo, backLabel }: TicketDetailViewProps) {
 
   const [itStaffUsers, setItStaffUsers] = useState<ManagedUser[]>([])
   const [resolutionSummary, setResolutionSummary] = useState('')
-  const [attachmentFilename, setAttachmentFilename] = useState('')
-  const [attachmentUrl, setAttachmentUrl] = useState('')
+  const [attachmentFile, setAttachmentFile] = useState<File | null>(null)
+  const [attachmentError, setAttachmentError] = useState<string | null>(null)
+  const [removingAttachmentId, setRemovingAttachmentId] = useState<number | null>(null)
+  const [removalReason, setRemovalReason] = useState('')
 
   const isStaff = user?.role === 'IT_STAFF' || user?.role === 'ADMINISTRATOR'
   const isRequester = user?.role === 'REQUESTER'
@@ -411,55 +424,149 @@ function TicketDetailView({ backTo, backLabel }: TicketDetailViewProps) {
 
           {tab === 'attachments' && (
             <>
-              <form
-                className="row g-2 mb-3"
-                onSubmit={(event) => {
-                  event.preventDefault()
-                  if (!attachmentFilename.trim() || !attachmentUrl.trim()) return
-                  runAction(() => addAttachment(token, ticket.id, attachmentFilename.trim(), attachmentUrl.trim())).then(
-                    () => {
-                      setAttachmentFilename('')
-                      setAttachmentUrl('')
-                    },
-                  )
-                }}
-              >
-                <div className="col-md-4">
-                  <input
-                    type="text"
-                    className="form-control"
-                    placeholder="Filename"
-                    value={attachmentFilename}
-                    onChange={(event) => setAttachmentFilename(event.target.value)}
-                  />
-                </div>
-                <div className="col-md-6">
-                  <input
-                    type="url"
-                    className="form-control"
-                    placeholder="https://..."
-                    value={attachmentUrl}
-                    onChange={(event) => setAttachmentUrl(event.target.value)}
-                  />
-                </div>
-                <div className="col-md-2">
-                  <button type="submit" className="btn btn-primary w-100">
-                    Add
-                  </button>
-                </div>
-              </form>
+              {(() => {
+                const activeCount = ticket.attachments.filter((attachment) => attachment.isActive).length
+                const limitReached = activeCount >= MAX_ACTIVE_ATTACHMENTS
+
+                return (
+                  <form
+                    className="mb-3"
+                    onSubmit={(event) => {
+                      event.preventDefault()
+                      if (!attachmentFile) return
+                      runAction(() => addAttachment(token, ticket.id, attachmentFile)).then(() => {
+                        setAttachmentFile(null)
+                        setAttachmentError(null)
+                      })
+                    }}
+                  >
+                    {limitReached ? (
+                      <p className="text-muted small mb-2">
+                        This ticket already has the maximum of {MAX_ACTIVE_ATTACHMENTS} active attachments. Remove one before
+                        adding another.
+                      </p>
+                    ) : (
+                      <div className="row g-2 align-items-center">
+                        <div className="col-md-8">
+                          <input
+                            type="file"
+                            className="form-control"
+                            accept={ALLOWED_ATTACHMENT_TYPES.join(',')}
+                            onChange={(event) => {
+                              const file = event.target.files?.[0] ?? null
+                              setAttachmentError(null)
+                              if (file && !ALLOWED_ATTACHMENT_TYPES.includes(file.type)) {
+                                setAttachmentError('Only JPG, PNG, WEBP, or PDF files are allowed.')
+                                setAttachmentFile(null)
+                                event.target.value = ''
+                                return
+                              }
+                              if (file && file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+                                setAttachmentError('File exceeds the 5 MB limit.')
+                                setAttachmentFile(null)
+                                event.target.value = ''
+                                return
+                              }
+                              setAttachmentFile(file)
+                            }}
+                          />
+                        </div>
+                        <div className="col-md-4">
+                          <button type="submit" className="btn btn-primary w-100" disabled={!attachmentFile}>
+                            Upload
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                    {attachmentError && <div className="text-danger small mt-2">{attachmentError}</div>}
+                  </form>
+                )
+              })()}
+
               {ticket.attachments.length === 0 ? (
                 <p className="text-muted text-center py-3">No attachments yet.</p>
               ) : (
                 <ul className="list-group list-group-flush">
                   {ticket.attachments.map((attachment) => (
-                    <li className="list-group-item px-0 d-flex justify-content-between align-items-center" key={attachment.id}>
-                      <a href={attachment.url} target="_blank" rel="noreferrer">
-                        {attachment.filename}
-                      </a>
-                      <span className="text-muted small">
-                        {attachment.uploader.fullName} - {formatDateTime(attachment.createdAt)}
-                      </span>
+                    <li className="list-group-item px-0" key={attachment.id}>
+                      <div className="d-flex justify-content-between align-items-start gap-2 flex-wrap">
+                        <div>
+                          <span className={attachment.isActive ? '' : 'text-muted text-decoration-line-through'}>
+                            {attachment.filename}
+                          </span>{' '}
+                          <span className="text-muted small">({formatFileSize(attachment.sizeBytes)})</span>
+                          <div className="text-muted small">
+                            {attachment.uploader.fullName} - {formatDateTime(attachment.createdAt)}
+                          </div>
+                          {!attachment.isActive && (
+                            <div className="text-muted small fst-italic">
+                              Removed by {attachment.removedBy?.fullName ?? 'unknown'} on {formatDateTime(attachment.removedAt)}
+                              {attachment.removedReason ? `: ${attachment.removedReason}` : ''}
+                            </div>
+                          )}
+                        </div>
+                        {attachment.isActive && (
+                          <div className="d-flex gap-2 text-nowrap">
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              onClick={() =>
+                                downloadAttachment(token, attachment.id, attachment.filename).catch((err) =>
+                                  setActionError(err instanceof ApiError ? err.message : 'Download failed.'),
+                                )
+                              }
+                            >
+                              Download
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-danger btn-sm"
+                              onClick={() => {
+                                setRemovingAttachmentId(attachment.id)
+                                setRemovalReason('')
+                              }}
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        )}
+                      </div>
+
+                      {removingAttachmentId === attachment.id && (
+                        <form
+                          className="d-flex gap-2 mt-2"
+                          onSubmit={(event) => {
+                            event.preventDefault()
+                            if (!removalReason.trim()) return
+                            runAction(() => removeAttachment(token, attachment.id, removalReason.trim())).then(() => {
+                              setRemovingAttachmentId(null)
+                              setRemovalReason('')
+                            })
+                          }}
+                        >
+                          <input
+                            type="text"
+                            className="form-control form-control-sm"
+                            placeholder="Reason for removal..."
+                            value={removalReason}
+                            onChange={(event) => setRemovalReason(event.target.value)}
+                            autoFocus
+                          />
+                          <button type="submit" className="btn btn-danger btn-sm text-nowrap" disabled={!removalReason.trim()}>
+                            Confirm removal
+                          </button>
+                          <button
+                            type="button"
+                            className="btn btn-outline-secondary btn-sm"
+                            onClick={() => {
+                              setRemovingAttachmentId(null)
+                              setRemovalReason('')
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </form>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
+        "multer": "^2.2.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -22,6 +23,7 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
+        "@types/multer": "^2.2.0",
         "@types/node": "^26.2.0",
         "@types/supertest": "^7.2.1",
         "dotenv-cli": "^11.0.0",
@@ -996,6 +998,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
@@ -1511,6 +1523,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -1586,6 +1604,23 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1724,6 +1759,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/confbox": {
@@ -3022,6 +3072,68 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -3360,6 +3472,20 @@
         "destr": "^2.0.3"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -3640,6 +3766,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -3779,6 +3922,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
@@ -3829,6 +3978,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
+    "multer": "^2.2.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -37,6 +38,7 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/multer": "^2.2.0",
     "@types/node": "^26.2.0",
     "@types/supertest": "^7.2.1",
     "dotenv-cli": "^11.0.0",

--- a/server/prisma/migrations/20260828140240_attachment_upload_metadata/migration.sql
+++ b/server/prisma/migrations/20260828140240_attachment_upload_metadata/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `url` on the `Attachment` table. All the data in the column will be lost.
+  - Added the required column `mimeType` to the `Attachment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `sizeBytes` to the `Attachment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `storedFilename` to the `Attachment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Attachment" DROP COLUMN "url",
+ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "mimeType" TEXT NOT NULL,
+ADD COLUMN     "removedAt" TIMESTAMP(3),
+ADD COLUMN     "removedById" INTEGER,
+ADD COLUMN     "removedReason" TEXT,
+ADD COLUMN     "sizeBytes" INTEGER NOT NULL,
+ADD COLUMN     "storedFilename" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_idx" ON "Attachment"("ticketId");
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_removedById_fkey" FOREIGN KEY ("removedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -39,12 +39,13 @@ model User {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  ticketsRequested Ticket[]        @relation("TicketRequester")
-  ticketsOwned     Ticket[]        @relation("TicketOwner")
-  publicComments   PublicComment[]
-  internalNotes    InternalNote[]
-  actionsTaken     ActionTaken[]
-  attachments      Attachment[]
+  ticketsRequested    Ticket[]        @relation("TicketRequester")
+  ticketsOwned        Ticket[]        @relation("TicketOwner")
+  publicComments      PublicComment[]
+  internalNotes       InternalNote[]
+  actionsTaken        ActionTaken[]
+  attachmentsUploaded Attachment[]    @relation("AttachmentUploader")
+  attachmentsRemoved  Attachment[]    @relation("AttachmentRemover")
 }
 
 model Category {
@@ -129,12 +130,21 @@ model ActionTaken {
 }
 
 model Attachment {
-  id         Int      @id @default(autoincrement())
-  ticketId   Int
-  ticket     Ticket   @relation(fields: [ticketId], references: [id], onDelete: Cascade)
-  uploaderId Int
-  uploader   User     @relation(fields: [uploaderId], references: [id], onDelete: Restrict)
-  filename   String
-  url        String
-  createdAt  DateTime @default(now())
+  id             Int       @id @default(autoincrement())
+  ticketId       Int
+  ticket         Ticket    @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  uploaderId     Int
+  uploader       User      @relation("AttachmentUploader", fields: [uploaderId], references: [id], onDelete: Restrict)
+  filename       String
+  storedFilename String
+  mimeType       String
+  sizeBytes      Int
+  isActive       Boolean   @default(true)
+  removedAt      DateTime?
+  removedById    Int?
+  removedBy      User?     @relation("AttachmentRemover", fields: [removedById], references: [id], onDelete: SetNull)
+  removedReason  String?
+  createdAt      DateTime  @default(now())
+
+  @@index([ticketId])
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import categoriesRoutes from './routes/categories.routes'
 import relatedSystemsRoutes from './routes/relatedSystems.routes'
 import usersRoutes from './routes/users.routes'
 import ticketsRoutes from './routes/tickets.routes'
+import attachmentsRoutes from './routes/attachments.routes'
 
 const app = express()
 
@@ -20,5 +21,6 @@ app.use('/api/categories', categoriesRoutes)
 app.use('/api/related-systems', relatedSystemsRoutes)
 app.use('/api/users', usersRoutes)
 app.use('/api/tickets', ticketsRoutes)
+app.use('/api/attachments', attachmentsRoutes)
 
 export default app

--- a/server/src/controllers/attachments.controller.ts
+++ b/server/src/controllers/attachments.controller.ts
@@ -1,0 +1,97 @@
+import type { RequestHandler } from 'express'
+import { z } from 'zod'
+import prisma from '../db'
+import { userCanAccessTicket } from '../lib/ticketAccess'
+import { storedFilePath } from '../lib/attachmentStorage'
+
+const PARTICIPANT_SELECT = { id: true, fullName: true, role: true } as const
+
+function parseId(raw: string | string[] | undefined): number | null {
+  if (typeof raw !== 'string') return null
+  const id = Number(raw)
+  return Number.isInteger(id) ? id : null
+}
+
+async function loadAccessibleAttachment(rawId: string | string[] | undefined, user: Parameters<typeof userCanAccessTicket>[1]) {
+  const id = parseId(rawId)
+  if (id === null) return { status: 400 as const, error: 'Invalid attachment id' }
+
+  const attachment = await prisma.attachment.findUnique({
+    where: { id },
+    include: { uploader: { select: PARTICIPANT_SELECT }, removedBy: { select: PARTICIPANT_SELECT } },
+  })
+  if (!attachment) return { status: 404 as const, error: 'Attachment not found' }
+
+  const hasAccess = await userCanAccessTicket(attachment.ticketId, user)
+  if (!hasAccess) return { status: 404 as const, error: 'Attachment not found' }
+
+  return { status: 200 as const, attachment }
+}
+
+export const getAttachment: RequestHandler = async (req, res) => {
+  const result = await loadAccessibleAttachment(req.params.id, req.user!)
+  if (result.status !== 200) {
+    res.status(result.status).json({ error: result.error })
+    return
+  }
+  res.status(200).json(result.attachment)
+}
+
+export const downloadAttachment: RequestHandler = async (req, res) => {
+  const result = await loadAccessibleAttachment(req.params.id, req.user!)
+  if (result.status !== 200) {
+    res.status(result.status).json({ error: result.error })
+    return
+  }
+
+  const { attachment } = result
+  if (!attachment.isActive) {
+    res.status(410).json({ error: 'This attachment has been removed and is no longer downloadable' })
+    return
+  }
+
+  res.download(storedFilePath(attachment.storedFilename), attachment.filename, (err) => {
+    if (err && !res.headersSent) {
+      res.status(404).json({ error: 'Attachment file not found' })
+    }
+  })
+}
+
+const removeSchema = z.object({ reason: z.string().min(1) })
+
+export const removeAttachment: RequestHandler = async (req, res) => {
+  const result = await loadAccessibleAttachment(req.params.id, req.user!)
+  if (result.status !== 200) {
+    res.status(result.status).json({ error: result.error })
+    return
+  }
+
+  const { attachment } = result
+  const isStaff = req.user!.role === 'IT_STAFF' || req.user!.role === 'ADMINISTRATOR'
+  if (attachment.uploaderId !== req.user!.id && !isStaff) {
+    res.status(403).json({ error: 'Only the uploader or IT staff can remove this attachment' })
+    return
+  }
+  if (!attachment.isActive) {
+    res.status(409).json({ error: 'This attachment has already been removed' })
+    return
+  }
+
+  const parsed = removeSchema.safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({ error: 'A removal reason is required' })
+    return
+  }
+
+  const updated = await prisma.attachment.update({
+    where: { id: attachment.id },
+    data: {
+      isActive: false,
+      removedAt: new Date(),
+      removedById: req.user!.id,
+      removedReason: parsed.data.reason,
+    },
+    include: { uploader: { select: PARTICIPANT_SELECT }, removedBy: { select: PARTICIPANT_SELECT } },
+  })
+  res.status(200).json(updated)
+}

--- a/server/src/controllers/tickets.controller.ts
+++ b/server/src/controllers/tickets.controller.ts
@@ -1,9 +1,11 @@
 import type { RequestHandler } from 'express'
+import fs from 'node:fs'
 import { z } from 'zod'
 import type { TicketStatus } from '@prisma/client'
 import prisma from '../db'
 import { formatTicketNumber } from '../lib/ticketNumber'
 import { loadTicketForUser, serializeTicket, userCanAccessTicket } from '../lib/ticketAccess'
+import { MAX_ACTIVE_ATTACHMENTS_PER_TICKET, sanitizeOriginalFilename } from '../lib/attachmentStorage'
 
 const PRIORITIES = ['LOW', 'MEDIUM', 'HIGH', 'URGENT'] as const
 const STATUSES = ['NEW', 'IN_PROGRESS', 'RESOLVED', 'CLOSED', 'REOPENED'] as const
@@ -429,24 +431,40 @@ export const updateAction: RequestHandler = async (req, res) => {
   }
 }
 
-const attachmentSchema = z.object({ filename: z.string().min(1), url: z.string().url() })
-
 export const addAttachment: RequestHandler = async (req, res) => {
   const ticketId = parseId(req.params.id)
-  const parsed = attachmentSchema.safeParse(req.body)
-  if (ticketId === null || !parsed.success) {
-    res.status(400).json({ error: 'filename and a valid url are required' })
+  if (ticketId === null) {
+    res.status(400).json({ error: 'Invalid ticket id' })
+    return
+  }
+  if (!req.file) {
+    res.status(400).json({ error: 'A file is required (field name "file")' })
     return
   }
 
   const hasAccess = await userCanAccessTicket(ticketId, req.user!)
   if (!hasAccess) {
+    await fs.promises.unlink(req.file.path).catch(() => {})
     res.status(404).json({ error: 'Ticket not found' })
     return
   }
 
+  const activeCount = await prisma.attachment.count({ where: { ticketId, isActive: true } })
+  if (activeCount >= MAX_ACTIVE_ATTACHMENTS_PER_TICKET) {
+    await fs.promises.unlink(req.file.path).catch(() => {})
+    res.status(409).json({ error: `A ticket may have at most ${MAX_ACTIVE_ATTACHMENTS_PER_TICKET} active attachments` })
+    return
+  }
+
   const attachment = await prisma.attachment.create({
-    data: { ticketId, uploaderId: req.user!.id, filename: parsed.data.filename, url: parsed.data.url },
+    data: {
+      ticketId,
+      uploaderId: req.user!.id,
+      filename: sanitizeOriginalFilename(req.file.originalname),
+      storedFilename: req.file.filename,
+      mimeType: req.file.mimetype,
+      sizeBytes: req.file.size,
+    },
     include: { uploader: { select: { id: true, fullName: true, role: true } } },
   })
   res.status(201).json(attachment)

--- a/server/src/lib/attachmentStorage.ts
+++ b/server/src/lib/attachmentStorage.ts
@@ -1,0 +1,42 @@
+import crypto from 'node:crypto'
+import path from 'node:path'
+import fs from 'node:fs'
+
+export const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024
+export const MAX_ACTIVE_ATTACHMENTS_PER_TICKET = 5
+
+const EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'application/pdf': '.pdf',
+}
+
+export const ALLOWED_MIME_TYPES = Object.keys(EXTENSION_BY_MIME_TYPE)
+
+export function isAllowedMimeType(mimeType: string): boolean {
+  return mimeType in EXTENSION_BY_MIME_TYPE
+}
+
+export const UPLOAD_DIR = path.join(__dirname, '..', '..', 'uploads', 'attachments')
+
+export function ensureUploadDir(): void {
+  fs.mkdirSync(UPLOAD_DIR, { recursive: true })
+}
+
+// A random name on disk, independent of the client-supplied filename, so a
+// crafted name (path traversal, double extensions, etc.) can never reach the
+// filesystem. The original filename is kept only as display metadata in the DB.
+export function generateStoredFilename(mimeType: string): string {
+  const extension = EXTENSION_BY_MIME_TYPE[mimeType] ?? ''
+  return `${crypto.randomUUID()}${extension}`
+}
+
+export function sanitizeOriginalFilename(rawName: string): string {
+  const base = path.basename(rawName).trim()
+  return base.length > 0 ? base.slice(0, 255) : 'attachment'
+}
+
+export function storedFilePath(storedFilename: string): string {
+  return path.join(UPLOAD_DIR, storedFilename)
+}

--- a/server/src/lib/ticketAccess.ts
+++ b/server/src/lib/ticketAccess.ts
@@ -14,7 +14,10 @@ export async function loadTicketForUser(ticketId: number, user: AuthenticatedUse
       publicComments: { include: { author: { select: PARTICIPANT_SELECT } }, orderBy: { createdAt: 'asc' } },
       internalNotes: { include: { author: { select: PARTICIPANT_SELECT } }, orderBy: { createdAt: 'asc' } },
       actionsTaken: { include: { author: { select: PARTICIPANT_SELECT } }, orderBy: { createdAt: 'asc' } },
-      attachments: { include: { uploader: { select: PARTICIPANT_SELECT } }, orderBy: { createdAt: 'asc' } },
+      attachments: {
+        include: { uploader: { select: PARTICIPANT_SELECT }, removedBy: { select: PARTICIPANT_SELECT } },
+        orderBy: { createdAt: 'asc' },
+      },
     },
   })
 

--- a/server/src/middleware/uploadAttachment.ts
+++ b/server/src/middleware/uploadAttachment.ts
@@ -1,0 +1,46 @@
+import multer from 'multer'
+import type { RequestHandler } from 'express'
+import {
+  ALLOWED_MIME_TYPES,
+  MAX_FILE_SIZE_BYTES,
+  UPLOAD_DIR,
+  ensureUploadDir,
+  generateStoredFilename,
+  isAllowedMimeType,
+} from '../lib/attachmentStorage'
+
+ensureUploadDir()
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, UPLOAD_DIR),
+  filename: (_req, file, cb) => cb(null, generateStoredFilename(file.mimetype)),
+})
+
+const upload = multer({
+  storage,
+  limits: { fileSize: MAX_FILE_SIZE_BYTES },
+  fileFilter: (_req, file, cb) => {
+    if (!isAllowedMimeType(file.mimetype)) {
+      cb(new Error(`Unsupported file type. Allowed types: ${ALLOWED_MIME_TYPES.join(', ')}`))
+      return
+    }
+    cb(null, true)
+  },
+})
+
+const uploadSingleAttachment: RequestHandler = (req, res, next) => {
+  upload.single('file')(req, res, (err: unknown) => {
+    if (!err) {
+      next()
+      return
+    }
+    if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+      res.status(400).json({ error: `File exceeds the ${MAX_FILE_SIZE_BYTES / (1024 * 1024)} MB limit` })
+      return
+    }
+    const message = err instanceof Error ? err.message : 'Unable to process the uploaded file'
+    res.status(400).json({ error: message })
+  })
+}
+
+export default uploadSingleAttachment

--- a/server/src/routes/attachments.routes.ts
+++ b/server/src/routes/attachments.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express'
+import requireAuth from '../middleware/requireAuth'
+import enforcePasswordChange from '../middleware/enforcePasswordChange'
+import { getAttachment, downloadAttachment, removeAttachment } from '../controllers/attachments.controller'
+
+const router = Router()
+
+router.use(requireAuth, enforcePasswordChange)
+
+router.get('/:id', getAttachment)
+router.get('/:id/download', downloadAttachment)
+router.delete('/:id', removeAttachment)
+
+export default router

--- a/server/src/routes/tickets.routes.ts
+++ b/server/src/routes/tickets.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import requireAuth from '../middleware/requireAuth'
 import { requireRole } from '../middleware/requireRole'
 import enforcePasswordChange from '../middleware/enforcePasswordChange'
+import uploadSingleAttachment from '../middleware/uploadAttachment'
 import * as tickets from '../controllers/tickets.controller'
 
 const router = Router()
@@ -29,6 +30,6 @@ router.post('/:id/actions', requireRole(...staffRoles), tickets.addAction)
 router.patch('/:id/actions/:actionId', requireRole(...staffRoles), tickets.updateAction)
 
 router.post('/:id/comments', tickets.addComment)
-router.post('/:id/attachments', tickets.addAttachment)
+router.post('/:id/attachments', uploadSingleAttachment, tickets.addAttachment)
 
 export default router

--- a/server/tests/full-app/attachments.test.ts
+++ b/server/tests/full-app/attachments.test.ts
@@ -1,0 +1,233 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import request from 'supertest'
+import app from '../../src/app'
+
+async function loginAs(email: string, password: string) {
+  const response = await request(app).post('/api/auth/login').send({ email, password })
+  return response.body.token as string
+}
+
+async function createTicket(token: string, categoryId: number, summary: string) {
+  const response = await request(app)
+    .post('/api/tickets')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ categoryId, summary, description: 'x' })
+  return response.body.id as number
+}
+
+describe('attachment upload, download, and soft removal', () => {
+  let requesterToken: string
+  let otherRequesterToken: string
+  let itStaffToken: string
+  let categoryId: number
+  let ticketId: number
+
+  beforeAll(async () => {
+    requesterToken = await loginAs('requester@toktickit.dev', 'Requester123!')
+    itStaffToken = await loginAs('itstaff@toktickit.dev', 'ItStaff123!')
+    const adminToken = await loginAs('admin@toktickit.dev', 'Admin123!')
+
+    const categories = await request(app).get('/api/categories')
+    categoryId = categories.body[0].id
+    ticketId = await createTicket(requesterToken, categoryId, `Attachment test ticket ${Date.now()}`)
+
+    const email = `attachment-other-${Date.now()}@toktickit.dev`
+    const created = await request(app)
+      .post('/api/users')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ email, fullName: 'Attachment Other', role: 'REQUESTER' })
+    const firstLogin = await request(app).post('/api/auth/login').send({ email, password: created.body.temporaryPassword })
+    await request(app)
+      .post('/api/auth/change-password')
+      .set('Authorization', `Bearer ${firstLogin.body.token}`)
+      .send({ currentPassword: created.body.temporaryPassword, newPassword: 'AttachmentOther123!' })
+    otherRequesterToken = (
+      await request(app).post('/api/auth/login').send({ email, password: 'AttachmentOther123!' })
+    ).body.token as string
+  })
+
+  it('rejects an unsupported file type', async () => {
+    const response = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .attach('file', Buffer.from('plain text content'), 'note.txt')
+    expect(response.status).toBe(400)
+    expect(response.body.error).toMatch(/unsupported file type/i)
+  })
+
+  it('rejects a file over the 5 MB limit', async () => {
+    const oversized = Buffer.alloc(5 * 1024 * 1024 + 1, 'a')
+    const response = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .attach('file', oversized, 'big.png')
+    expect(response.status).toBe(400)
+    expect(response.body.error).toMatch(/5 MB limit/i)
+  })
+
+  it('rejects an upload with no file', async () => {
+    const response = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects an upload from a requester who does not own the ticket', async () => {
+    const response = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set('Authorization', `Bearer ${otherRequesterToken}`)
+      .attach('file', Buffer.from('%PDF-1.4 fake pdf'), 'doc.pdf')
+    expect(response.status).toBe(404)
+  })
+
+  it('accepts a valid PDF upload and stores its metadata', async () => {
+    // ticket now has 1 active attachment
+    const response = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .attach('file', Buffer.from('%PDF-1.4 fake pdf content'), 'evidence.pdf')
+
+    expect(response.status).toBe(201)
+    expect(response.body).toMatchObject({ filename: 'evidence.pdf', mimeType: 'application/pdf', isActive: true })
+    expect(response.body.sizeBytes).toBeGreaterThan(0)
+    expect(response.body.storedFilename).not.toBe('evidence.pdf')
+  })
+
+  it('rejects removal from the ticket owner when a different (staff) user uploaded it', async () => {
+    // ticket now has 2 active attachments
+    const staffUpload = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set('Authorization', `Bearer ${itStaffToken}`)
+      .attach('file', Buffer.from('staff uploaded file'), 'staff-upload.png')
+    expect(staffUpload.status).toBe(201)
+
+    // the requester owns the ticket (so has access) but is neither the
+    // uploader nor staff - should be rejected, not just silently allowed
+    // because they can access the ticket
+    const response = await request(app)
+      .delete(`/api/attachments/${staffUpload.body.id}`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .send({ reason: 'requester should not be able to remove this' })
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects removal from a requester with no access to the ticket at all', async () => {
+    const ticket = await request(app).get(`/api/tickets/${ticketId}`).set('Authorization', `Bearer ${requesterToken}`)
+    const attachmentId = ticket.body.attachments[0].id
+
+    const response = await request(app)
+      .delete(`/api/attachments/${attachmentId}`)
+      .set('Authorization', `Bearer ${otherRequesterToken}`)
+      .send({ reason: 'not mine to remove' })
+    expect(response.status).toBe(404)
+  })
+
+  it('enforces a maximum of 5 active attachments per ticket', async () => {
+    // 2 active attachments exist already; add 3 more to reach the cap of 5
+    for (let i = 0; i < 3; i++) {
+      const response = await request(app)
+        .post(`/api/tickets/${ticketId}/attachments`)
+        .set('Authorization', `Bearer ${requesterToken}`)
+        .attach('file', Buffer.from(`fake image ${i}`), `photo-${i}.png`)
+      expect(response.status).toBe(201)
+    }
+
+    const sixth = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .attach('file', Buffer.from('one too many'), 'photo-extra.png')
+    expect(sixth.status).toBe(409)
+    expect(sixth.body.error).toMatch(/at most 5/i)
+  })
+
+  it('lets the owning requester download an active attachment, but not another requester', async () => {
+    const ticket = await request(app).get(`/api/tickets/${ticketId}`).set('Authorization', `Bearer ${requesterToken}`)
+    const attachmentId = ticket.body.attachments.find((a: { isActive: boolean }) => a.isActive).id
+
+    const mine = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+    expect(mine.status).toBe(200)
+
+    const notMine = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set('Authorization', `Bearer ${otherRequesterToken}`)
+    expect(notMine.status).toBe(404)
+  })
+
+  it('lets IT staff view attachment metadata on a ticket they can access', async () => {
+    const ticket = await request(app).get(`/api/tickets/${ticketId}`).set('Authorization', `Bearer ${requesterToken}`)
+    const attachmentId = ticket.body.attachments[0].id
+
+    const response = await request(app).get(`/api/attachments/${attachmentId}`).set('Authorization', `Bearer ${itStaffToken}`)
+    expect(response.status).toBe(200)
+    expect(response.body.id).toBe(attachmentId)
+  })
+
+  it('requires a reason to soft-remove an attachment', async () => {
+    const ticket = await request(app).get(`/api/tickets/${ticketId}`).set('Authorization', `Bearer ${requesterToken}`)
+    const attachmentId = ticket.body.attachments.find((a: { isActive: boolean }) => a.isActive).id
+
+    const response = await request(app)
+      .delete(`/api/attachments/${attachmentId}`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .send({})
+    expect(response.status).toBe(400)
+  })
+
+  it('soft-removes an attachment: metadata stays visible, download is blocked, and the freed slot allows a new upload', async () => {
+    const ticket = await request(app).get(`/api/tickets/${ticketId}`).set('Authorization', `Bearer ${requesterToken}`)
+    const attachmentId = ticket.body.attachments.find((a: { isActive: boolean }) => a.isActive).id
+
+    const removed = await request(app)
+      .delete(`/api/attachments/${attachmentId}`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .send({ reason: 'Uploaded the wrong file' })
+    expect(removed.status).toBe(200)
+    expect(removed.body).toMatchObject({ isActive: false, removedReason: 'Uploaded the wrong file' })
+    expect(removed.body.removedBy).toMatchObject({ id: expect.any(Number) })
+
+    // metadata still visible
+    const metadata = await request(app).get(`/api/attachments/${attachmentId}`).set('Authorization', `Bearer ${requesterToken}`)
+    expect(metadata.status).toBe(200)
+    expect(metadata.body.isActive).toBe(false)
+
+    // the full ticket-detail payload (what the UI actually renders from)
+    // must also carry removedBy, not just the single-attachment endpoint
+    const ticketAfterRemoval = await request(app).get(`/api/tickets/${ticketId}`).set('Authorization', `Bearer ${requesterToken}`)
+    const sameAttachment = ticketAfterRemoval.body.attachments.find((a: { id: number }) => a.id === attachmentId)
+    expect(sameAttachment.removedBy).toMatchObject({ id: expect.any(Number), fullName: expect.any(String) })
+
+    // download now blocked
+    const download = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+    expect(download.status).toBe(410)
+
+    // removing it again is rejected
+    const again = await request(app)
+      .delete(`/api/attachments/${attachmentId}`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .send({ reason: 'trying again' })
+    expect(again.status).toBe(409)
+
+    // the freed slot allows a new upload even though the ticket was at the cap
+    const reupload = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .attach('file', Buffer.from('replacement file'), 'replacement.png')
+    expect(reupload.status).toBe(201)
+  })
+
+  it('lets IT staff remove an attachment they did not upload', async () => {
+    const ticket = await request(app).get(`/api/tickets/${ticketId}`).set('Authorization', `Bearer ${requesterToken}`)
+    const activeAttachment = ticket.body.attachments.find((a: { isActive: boolean }) => a.isActive)
+
+    const response = await request(app)
+      .delete(`/api/attachments/${activeAttachment.id}`)
+      .set('Authorization', `Bearer ${itStaffToken}`)
+      .send({ reason: 'Staff cleanup' })
+    expect(response.status).toBe(200)
+    expect(response.body.isActive).toBe(false)
+  })
+})

--- a/server/tests/full-app/attachments.test.ts
+++ b/server/tests/full-app/attachments.test.ts
@@ -204,6 +204,13 @@ describe('attachment upload, download, and soft removal', () => {
       .set('Authorization', `Bearer ${requesterToken}`)
     expect(download.status).toBe(410)
 
+    // there is no separate "preview" route or static file serving that
+    // could bypass the isActive check above - the only way to reach the
+    // file's bytes at all is the (now-blocked) download endpoint. Guessing
+    // the real on-disk filename via a static-style URL must not work either.
+    const guessedStaticUrl = await request(app).get(`/uploads/attachments/${metadata.body.storedFilename}`)
+    expect(guessedStaticUrl.status).toBe(404)
+
     // removing it again is rejected
     const again = await request(app)
       .delete(`/api/attachments/${attachmentId}`)


### PR DESCRIPTION
﻿## Summary
Attachments previously stored only a client-supplied `{filename, url}` pair - no real file, no validation, no removal capability. This implements the Lab 2 attachment rules for real:

- Real multipart file upload (multer), not a URL text field
- Type allowlist: JPG/JPEG, PNG, WEBP, PDF (server-enforced via MIME type)
- 5 MB max per file
- Max 5 active attachments per ticket
- Files stored under `server/uploads/` (gitignored) with a random UUID filename - the client-supplied name is display-only metadata, never used as a filesystem path
- New `GET /api/attachments/:id` (metadata), `GET /api/attachments/:id/download` (blocked with 410 once removed), `DELETE /api/attachments/:id` (soft removal, requires a reason, restricted to the uploader or IT Staff/Administrator)
- Schema migration adds `storedFilename`, `mimeType`, `sizeBytes`, `isActive`, `removedAt`, `removedById`, `removedReason` to `Attachment`

Frontend: real file picker with client-side type/size pre-check, a Download button that fetches with auth and saves via a blob URL, and an inline Remove flow (reason field + confirm/cancel). Removed attachments show strikethrough + "Removed by X: reason"; the upload form hides once the 5-attachment cap is hit.

## Testing
- `npm test --prefix server`: 7 files, 45 tests (13 new)
- `npm test --prefix client`: 4 files, 13 tests
- `npm run build` passes on both
- Full Playwright walkthrough against the running dev servers - and it caught a real bug: `loadTicketForUser` wasn't including the `removedBy` relation, so the Ticket Detail screen showed "Removed by unknown" even though the direct attachment endpoints had the right data. Fixed, with a regression test asserting `GET /api/tickets/:id` itself carries `removedBy`.

Related to #23.
