### PR TITLE
Seed an inactive requester user

### DIFF
--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -13,6 +13,7 @@ type SeedUser = {
   fullName: string
   role: Role
   mustChangePassword: boolean
+  isActive?: boolean
 }
 
 const SEED_USERS: SeedUser[] = [
@@ -44,6 +45,17 @@ const SEED_USERS: SeedUser[] = [
     role: Role.REQUESTER,
     mustChangePassword: true,
   },
+  {
+    // Lab 2 requires at least one inactive Development Requester in the seed
+    // data (labsheet Section 5.3), so login/list behavior against a
+    // deactivated account can be demonstrated and tested.
+    email: 'inactive-requester@toktickit.dev',
+    password: 'InactiveRequester123!',
+    fullName: 'Ida Inactive',
+    role: Role.REQUESTER,
+    mustChangePassword: false,
+    isActive: false,
+  },
 ]
 
 async function main() {
@@ -74,6 +86,7 @@ async function main() {
         fullName: seedUser.fullName,
         role: seedUser.role,
         mustChangePassword: seedUser.mustChangePassword,
+        isActive: seedUser.isActive ?? true,
       },
     })
   }

--- a/server/tests/full-app/auth.test.ts
+++ b/server/tests/full-app/auth.test.ts
@@ -34,6 +34,14 @@ describe('POST /api/auth/login', () => {
     expect(response.status).toBe(401)
   })
 
+  it('rejects a correct password for a deactivated (inactive) user', async () => {
+    const response = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'inactive-requester@toktickit.dev', password: 'InactiveRequester123!' })
+
+    expect(response.status).toBe(401)
+  })
+
   it('rejects a malformed request body', async () => {
     const response = await request(app).post('/api/auth/login').send({ email: 'not-an-email' })
 


### PR DESCRIPTION
﻿## Summary
Lab 2 requires the seed data to include at least one inactive Development Requester (labsheet Section 5.3) - none existed. Adds `inactive-requester@toktickit.dev` with `isActive: false`, plus a regression test confirming login is rejected for a deactivated user.

## Testing
`npm test --prefix server`: 6 files, 33 tests, all passing.
