### PR TITLE
Create Ticket: per-field validation and inline attachment upload

### DIFF
--- a/client/src/pages/CreateTicketPage.tsx
+++ b/client/src/pages/CreateTicketPage.tsx
@@ -3,12 +3,21 @@ import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
 import { fetchCategories, type Category } from '../api/categories'
 import { fetchRelatedSystems, type RelatedSystem } from '../api/relatedSystems'
-import { createTicket, type Priority } from '../api/tickets'
+import {
+  createTicket,
+  addAttachment,
+  ALLOWED_ATTACHMENT_TYPES,
+  MAX_ATTACHMENT_SIZE_BYTES,
+  MAX_ACTIVE_ATTACHMENTS,
+  type Priority,
+} from '../api/tickets'
 import { ApiError } from '../api/client'
 import ErrorAlert from '../components/ErrorAlert'
 import LoadingSpinner from '../components/LoadingSpinner'
 
 const PRIORITY_OPTIONS: Priority[] = ['LOW', 'MEDIUM', 'HIGH', 'URGENT']
+
+type FieldErrors = { summary?: string; description?: string }
 
 function CreateTicketPage() {
   const { token } = useAuth()
@@ -24,8 +33,14 @@ function CreateTicketPage() {
   const [summary, setSummary] = useState('')
   const [description, setDescription] = useState('')
   const [requestedPriority, setRequestedPriority] = useState<Priority>('MEDIUM')
+  const [attachmentFiles, setAttachmentFiles] = useState<File[]>([])
+  const [attachmentError, setAttachmentError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [partialUploadNotice, setPartialUploadNotice] = useState<{ ticketId: number; ticketNumber: string; failedCount: number } | null>(
+    null,
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -47,12 +62,52 @@ function CreateTicketPage() {
     }
   }, [])
 
+  const handleAttachmentChange = (fileList: FileList | null) => {
+    setAttachmentError(null)
+    if (!fileList || fileList.length === 0) return
+
+    const incoming = Array.from(fileList)
+    const remainingSlots = MAX_ACTIVE_ATTACHMENTS - attachmentFiles.length
+    if (incoming.length > remainingSlots) {
+      setAttachmentError(`You can attach at most ${MAX_ACTIVE_ATTACHMENTS} files. Only ${remainingSlots} more can be added.`)
+      return
+    }
+
+    for (const file of incoming) {
+      if (!ALLOWED_ATTACHMENT_TYPES.includes(file.type)) {
+        setAttachmentError(`"${file.name}" is not an allowed type. Only JPG, PNG, WEBP, or PDF files are allowed.`)
+        return
+      }
+      if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+        setAttachmentError(`"${file.name}" exceeds the 5 MB limit.`)
+        return
+      }
+    }
+
+    setAttachmentFiles((prev) => [...prev, ...incoming])
+  }
+
+  const removeSelectedAttachment = (index: number) => {
+    setAttachmentFiles((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const validate = (): FieldErrors => {
+    const errors: FieldErrors = {}
+    if (!summary.trim()) errors.summary = 'Summary is required.'
+    else if (summary.trim().length > 200) errors.summary = 'Summary must be 200 characters or fewer.'
+    if (!description.trim()) errors.description = 'Description is required.'
+    return errors
+  }
+
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
     setSubmitError(null)
+    setPartialUploadNotice(null)
 
-    if (!token || !categoryId || !summary.trim() || !description.trim()) {
-      setSubmitError('Category, summary, and description are required.')
+    const errors = validate()
+    setFieldErrors(errors)
+    if (Object.keys(errors).length > 0 || !token || !categoryId) {
+      if (!categoryId) setSubmitError('A category is required.')
       return
     }
 
@@ -65,10 +120,28 @@ function CreateTicketPage() {
         description: description.trim(),
         requestedPriority,
       })
+
+      // the ticket is created at this point regardless of what happens
+      // below - attachment upload failures must not make it look like ticket
+      // creation itself failed
+      let failedCount = 0
+      for (const file of attachmentFiles) {
+        try {
+          await addAttachment(token, ticket.id, file)
+        } catch {
+          failedCount += 1
+        }
+      }
+
+      if (failedCount > 0) {
+        setPartialUploadNotice({ ticketId: ticket.id, ticketNumber: ticket.ticketNumber, failedCount })
+        setIsSubmitting(false)
+        return
+      }
+
       navigate(`/tickets/${ticket.id}`)
     } catch (err) {
       setSubmitError(err instanceof ApiError ? err.message : 'Unable to create ticket.')
-    } finally {
       setIsSubmitting(false)
     }
   }
@@ -81,6 +154,15 @@ function CreateTicketPage() {
 
       {isLoadingOptions ? (
         <LoadingSpinner />
+      ) : partialUploadNotice ? (
+        <div className="card p-4 shadow-sm">
+          <ErrorAlert
+            message={`Ticket ${partialUploadNotice.ticketNumber} was created, but ${partialUploadNotice.failedCount} attachment(s) failed to upload. You can add them from the ticket detail page.`}
+          />
+          <button type="button" className="btn btn-primary" onClick={() => navigate(`/tickets/${partialUploadNotice.ticketId}`)}>
+            Go to ticket
+          </button>
+        </div>
       ) : (
         <form onSubmit={handleSubmit} className="card p-4 shadow-sm">
           {submitError && <ErrorAlert message={submitError} />}
@@ -132,12 +214,15 @@ function CreateTicketPage() {
             <input
               id="summary"
               type="text"
-              className="form-control"
+              className={`form-control ${fieldErrors.summary ? 'is-invalid' : ''}`}
               value={summary}
-              onChange={(event) => setSummary(event.target.value)}
+              onChange={(event) => {
+                setSummary(event.target.value)
+                if (fieldErrors.summary) setFieldErrors((prev) => ({ ...prev, summary: undefined }))
+              }}
               maxLength={200}
-              required
             />
+            {fieldErrors.summary && <div className="invalid-feedback">{fieldErrors.summary}</div>}
           </div>
 
           <div className="mb-3">
@@ -146,12 +231,15 @@ function CreateTicketPage() {
             </label>
             <textarea
               id="description"
-              className="form-control"
+              className={`form-control ${fieldErrors.description ? 'is-invalid' : ''}`}
               rows={5}
               value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              required
+              onChange={(event) => {
+                setDescription(event.target.value)
+                if (fieldErrors.description) setFieldErrors((prev) => ({ ...prev, description: undefined }))
+              }}
             />
+            {fieldErrors.description && <div className="invalid-feedback">{fieldErrors.description}</div>}
           </div>
 
           <div className="mb-4">
@@ -170,6 +258,37 @@ function CreateTicketPage() {
                 </option>
               ))}
             </select>
+          </div>
+
+          <div className="mb-4">
+            <label htmlFor="attachments" className="form-label">
+              Attachments <span className="text-muted">(optional, up to {MAX_ACTIVE_ATTACHMENTS} files, JPG/PNG/WEBP/PDF, 5 MB each)</span>
+            </label>
+            <input
+              id="attachments"
+              type="file"
+              className="form-control"
+              accept={ALLOWED_ATTACHMENT_TYPES.join(',')}
+              multiple
+              disabled={attachmentFiles.length >= MAX_ACTIVE_ATTACHMENTS}
+              onChange={(event) => {
+                handleAttachmentChange(event.target.files)
+                event.target.value = ''
+              }}
+            />
+            {attachmentError && <div className="text-danger small mt-1">{attachmentError}</div>}
+            {attachmentFiles.length > 0 && (
+              <ul className="list-group mt-2">
+                {attachmentFiles.map((file, index) => (
+                  <li key={`${file.name}-${index}`} className="list-group-item d-flex justify-content-between align-items-center py-1">
+                    <span className="text-truncate">{file.name}</span>
+                    <button type="button" className="btn btn-sm btn-outline-secondary" onClick={() => removeSelectedAttachment(index)}>
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
 
           <div className="d-flex gap-2">

--- a/client/src/pages/CreateTicketPage.tsx
+++ b/client/src/pages/CreateTicketPage.tsx
@@ -170,7 +170,7 @@ function CreateTicketPage() {
           <div className="row g-3 mb-3">
             <div className="col-md-6">
               <label htmlFor="category" className="form-label">
-                Category
+                Category <span className="text-danger">*</span>
               </label>
               <select
                 id="category"
@@ -209,7 +209,7 @@ function CreateTicketPage() {
 
           <div className="mb-3">
             <label htmlFor="summary" className="form-label">
-              Summary
+              Summary <span className="text-danger">*</span>
             </label>
             <input
               id="summary"
@@ -227,7 +227,7 @@ function CreateTicketPage() {
 
           <div className="mb-3">
             <label htmlFor="description" className="form-label">
-              Description
+              Description <span className="text-danger">*</span>
             </label>
             <textarea
               id="description"

--- a/client/tests/full-app/pages.test.tsx
+++ b/client/tests/full-app/pages.test.tsx
@@ -119,7 +119,7 @@ describe('CreateTicketPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('option', { name: 'Hardware' })).toBeInTheDocument()
     })
-    expect(screen.getByLabelText('Summary')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Summary/)).toBeInTheDocument()
   })
 
   it('shows field-level validation messages on an empty submit, without calling the create-ticket API', async () => {

--- a/client/tests/full-app/pages.test.tsx
+++ b/client/tests/full-app/pages.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthProvider } from '../../src/auth/AuthContext'
@@ -119,6 +120,37 @@ describe('CreateTicketPage', () => {
       expect(screen.getByRole('option', { name: 'Hardware' })).toBeInTheDocument()
     })
     expect(screen.getByLabelText('Summary')).toBeInTheDocument()
+  })
+
+  it('shows field-level validation messages on an empty submit, without calling the create-ticket API', async () => {
+    const fetchMock = mockFetchImpl({
+      '/api/auth/me': { user: REQUESTER },
+      '/api/categories': [{ id: 1, name: 'Hardware' }],
+      '/api/related-systems': [],
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <CreateTicketPage />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Hardware' })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit Ticket' }))
+
+    expect(await screen.findByText('Summary is required.')).toBeInTheDocument()
+    expect(screen.getByText('Description is required.')).toBeInTheDocument()
+
+    const postedTicketCreation = fetchMock.mock.calls.some(
+      ([url, options]) => String(url).includes('/api/tickets') && !String(url).includes('categories') && !String(url).includes('related-systems') && (options as { method?: string } | undefined)?.method === 'POST',
+    )
+    expect(postedTicketCreation).toBe(false)
   })
 })
 


### PR DESCRIPTION
﻿## Summary
Closes two gaps flagged against `docs/lab-02/ui-spec.md`:

1. **Field-level validation** on Create Ticket - Summary/Description now show their own message under the field instead of one generic alert, clearing as the user edits. Labsheet 8.3 asks for messages "near the associated field."
2. **Attachments on the Create Ticket screen itself** - a multi-file picker (same type/5MB/5-file rules as the Ticket Detail Attachments tab) lets a Requester attach files while creating the ticket, per labsheet Section 4.4 listing Attachments as a Create Ticket field.

If a file fails to upload after the ticket is created, the user sees "Ticket TKT-XXXX was created, but N attachment(s) failed" with a link to the ticket - the ticket itself is never treated as failed (labsheet Section 4.5's "ticket created but attachment upload fails" case).

**Stacked PR:** base is `feature/23-attachment-validation-soft-removal`, not `dev/full-app`, since this depends on that PR's file-upload `addAttachment` API. Once #32 merges, this should be re-targeted at `dev/full-app` (or just merge #32 first, then this).

## Testing
`npm run build --prefix client` passes. `npm test --prefix client`: 4 files, 14 tests (adds a test asserting field-level messages + no `POST /api/tickets` call on an empty submit). Verified in a real browser: empty-submit shows both field messages, attaching a file and submitting creates the ticket with the file already attached, no console errors.

Related to #23. Also addresses two items flagged in `docs/lab-02/ui-spec.md`.
