### PR TITLE
Add a real Development Requester Selector

### DIFF
--- a/client/src/api/requesters.ts
+++ b/client/src/api/requesters.ts
@@ -1,0 +1,7 @@
+import { apiFetch } from './client'
+
+export type ActiveRequester = { id: number; fullName: string; email: string }
+
+export function fetchActiveRequesters() {
+  return apiFetch<ActiveRequester[]>('/api/requesters')
+}

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -1,3 +1,4 @@
+import { flushSync } from 'react-dom'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
 
@@ -7,9 +8,20 @@ function NavBar() {
 
   if (!user) return null
 
+  // logout() and navigate() are both async state updates; without flushSync,
+  // ProtectedRoute can render (with the freshly-cleared user) before our
+  // explicit navigate() commits, and its own "redirect to /login when
+  // logged out" logic races with - and can override - the destination we
+  // actually want (most visibly for Change Requester, which must not land
+  // on /login).
   const handleLogout = () => {
-    logout()
+    flushSync(() => logout())
     navigate('/login')
+  }
+
+  const handleChangeRequester = () => {
+    flushSync(() => logout())
+    navigate('/dev-requester-select')
   }
 
   return (
@@ -37,6 +49,11 @@ function NavBar() {
           <span className="text-white-50 small">
             {user.fullName} ({user.role})
           </span>
+          {user.role === 'REQUESTER' && (
+            <button type="button" className="btn btn-outline-light btn-sm" onClick={handleChangeRequester}>
+              Change Requester
+            </button>
+          )}
           <button type="button" className="btn btn-outline-light btn-sm" onClick={handleLogout}>
             Log out
           </button>

--- a/client/src/pages/DevRequesterSelectPage.tsx
+++ b/client/src/pages/DevRequesterSelectPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { useAuth } from '../auth/useAuth'
+import { fetchActiveRequesters, type ActiveRequester } from '../api/requesters'
+import { ApiError } from '../api/client'
+import ErrorAlert from '../components/ErrorAlert'
+import LoadingSpinner from '../components/LoadingSpinner'
+import EmptyState from '../components/EmptyState'
+
+// Lab 2's seeded Requester test accounts and their known (non-secret) local
+// dev passwords - see server/prisma/seed.ts and the root README. This lets
+// the selector sign a chosen Requester in through the app's real
+// authentication (POST /api/auth/login) rather than bypassing it: there is
+// no separate "fake session" mechanism, no new backend auth path, and no
+// endpoint that hands out credentials. If an account isn't in this map (e.g.
+// a Requester an Administrator created later, with an unknown generated
+// password), it simply can't be auto-signed-in here - the note below the
+// dropdown says so, and the real Login page is always the fallback.
+const DEV_REQUESTER_CREDENTIALS: Record<string, string> = {
+  'requester@toktickit.dev': 'Requester123!',
+}
+
+function DevRequesterSelectPage() {
+  const { user, login } = useAuth()
+  const navigate = useNavigate()
+
+  const [requesters, setRequesters] = useState<ActiveRequester[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState('')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchActiveRequesters()
+      .then((data) => {
+        if (cancelled) return
+        setRequesters(data)
+        if (data.length > 0) setSelectedId(String(data[0].id))
+      })
+      .catch((err) => {
+        if (!cancelled) setLoadError(err instanceof ApiError ? err.message : 'Unable to load Development Requesters.')
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (user) return <Navigate to="/dashboard" replace />
+
+  const selected = requesters.find((r) => String(r.id) === selectedId)
+  const knownPassword = selected ? DEV_REQUESTER_CREDENTIALS[selected.email] : undefined
+
+  const handleContinue = async () => {
+    if (!selected || !knownPassword) return
+    setSubmitError(null)
+    setIsSubmitting(true)
+    try {
+      await login(selected.email, knownPassword)
+      navigate('/dashboard')
+    } catch (err) {
+      setSubmitError(err instanceof ApiError ? err.message : 'Unable to sign in as this Development Requester.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="container" style={{ maxWidth: 480 }}>
+      <div className="py-5">
+        <h1 className="text-center mb-1">TokTickIT</h1>
+        <p className="text-center text-muted mb-4">Select Development Requester</p>
+
+        <div className="card p-4 shadow-sm">
+          <p className="text-muted small">
+            Choose a Development Requester to test requester-specific ticket behavior. This is a testing
+            convenience: selecting a Requester signs you in through the same secure sign-in as the rest of the
+            app (using that seeded account's credentials), not a separate mechanism.
+          </p>
+
+          {loadError && <ErrorAlert message={loadError} />}
+          {submitError && <ErrorAlert message={submitError} />}
+
+          {isLoading ? (
+            <LoadingSpinner />
+          ) : requesters.length === 0 ? (
+            <EmptyState message="No active Development Requesters are available." />
+          ) : (
+            <>
+              <div className="mb-3">
+                <label htmlFor="requester" className="form-label">
+                  Development Requester
+                </label>
+                <select
+                  id="requester"
+                  className="form-select"
+                  value={selectedId}
+                  onChange={(event) => setSelectedId(event.target.value)}
+                >
+                  {requesters.map((requester) => (
+                    <option key={requester.id} value={requester.id}>
+                      {requester.fullName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {selected && !knownPassword && (
+                <p className="text-muted small">
+                  No stored test credentials for this account. Use the <Link to="/login">Login page</Link> directly
+                  instead.
+                </p>
+              )}
+
+              <button
+                type="button"
+                className="btn btn-primary w-100"
+                disabled={!selected || !knownPassword || isSubmitting}
+                onClick={handleContinue}
+              >
+                {isSubmitting ? 'Signing in...' : 'Continue'}
+              </button>
+            </>
+          )}
+
+          <hr className="my-4" />
+          <p className="text-muted small mb-0 text-center">
+            Not testing as a Requester? <Link to="/login">Sign in normally</Link>.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default DevRequesterSelectPage

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { Navigate, useLocation, useNavigate } from 'react-router-dom'
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
 import { ApiError } from '../api/client'
 import ErrorAlert from '../components/ErrorAlert'
@@ -74,6 +74,11 @@ function LoginPage() {
           <button type="submit" className="btn btn-primary w-100" disabled={isSubmitting}>
             {isSubmitting ? 'Signing in...' : 'Sign in'}
           </button>
+
+          <hr className="my-4" />
+          <p className="text-muted small mb-0 text-center">
+            Testing as a Requester? <Link to="/dev-requester-select">Use the Development Requester Selector</Link>.
+          </p>
         </form>
       </div>
     </div>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -3,6 +3,7 @@ import { useAuth } from './auth/useAuth'
 import ProtectedRoute from './auth/ProtectedRoute'
 import NavBar from './components/NavBar'
 import LoginPage from './pages/LoginPage'
+import DevRequesterSelectPage from './pages/DevRequesterSelectPage'
 import FirstPasswordChangePage from './pages/FirstPasswordChangePage'
 import RequesterDashboardPage from './pages/RequesterDashboardPage'
 import CreateTicketPage from './pages/CreateTicketPage'
@@ -31,6 +32,7 @@ function AppRouter() {
       <NavBar />
       <Routes>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/dev-requester-select" element={<DevRequesterSelectPage />} />
         <Route
           path="/first-password-change"
           element={

--- a/client/tests/full-app/devRequesterSelect.test.tsx
+++ b/client/tests/full-app/devRequesterSelect.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthProvider } from '../../src/auth/AuthContext'
+import DevRequesterSelectPage from '../../src/pages/DevRequesterSelectPage'
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    headers: { get: () => 'application/json' },
+    json: async () => body,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/dev-requester-select']}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/dev-requester-select" element={<DevRequesterSelectPage />} />
+          <Route path="/dashboard" element={<div>Dashboard loaded</div>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('DevRequesterSelectPage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+  afterEach(() => {
+    localStorage.clear()
+    vi.unstubAllGlobals()
+  })
+
+  it('loads active Development Requesters and signs in through the real login endpoint on Continue', async () => {
+    const loginCalls: Array<{ email: string; password: string }> = []
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, options?: { method?: string; body?: string }) => {
+        const path = url.replace('http://localhost:4000', '')
+        if (path === '/api/requesters') {
+          return Promise.resolve(
+            jsonResponse([{ id: 3, fullName: 'Rachel Requester', email: 'requester@toktickit.dev' }]),
+          )
+        }
+        if (path === '/api/auth/login' && options?.method === 'POST') {
+          const body = JSON.parse(options.body ?? '{}')
+          loginCalls.push(body)
+          return Promise.resolve(
+            jsonResponse({
+              token: 'fake-token',
+              user: { id: 3, email: body.email, fullName: 'Rachel Requester', role: 'REQUESTER', mustChangePassword: false },
+            }),
+          )
+        }
+        return Promise.resolve(jsonResponse({}))
+      }),
+    )
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Rachel Requester' })).toBeInTheDocument()
+    })
+
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    expect(continueButton).not.toBeDisabled()
+
+    await userEvent.click(continueButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Dashboard loaded')).toBeInTheDocument()
+    })
+
+    expect(loginCalls).toEqual([{ email: 'requester@toktickit.dev', password: 'Requester123!' }])
+  })
+
+  it('shows an empty state when no active Development Requesters exist', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        const path = url.replace('http://localhost:4000', '')
+        if (path === '/api/requesters') return Promise.resolve(jsonResponse([]))
+        return Promise.resolve(jsonResponse({}))
+      }),
+    )
+
+    renderPage()
+
+    expect(await screen.findByText('No active Development Requesters are available.')).toBeInTheDocument()
+  })
+
+  it('shows a safe failure state when the requester list fails to load', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        const path = url.replace('http://localhost:4000', '')
+        if (path === '/api/requesters') {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            headers: { get: () => 'application/json' },
+            json: async () => ({ error: 'Something went wrong' }),
+          })
+        }
+        return Promise.resolve(jsonResponse({}))
+      }),
+    )
+
+    renderPage()
+
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument()
+  })
+})

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,7 @@ import relatedSystemsRoutes from './routes/relatedSystems.routes'
 import usersRoutes from './routes/users.routes'
 import ticketsRoutes from './routes/tickets.routes'
 import attachmentsRoutes from './routes/attachments.routes'
+import requestersRoutes from './routes/requesters.routes'
 
 const app = express()
 
@@ -22,5 +23,6 @@ app.use('/api/related-systems', relatedSystemsRoutes)
 app.use('/api/users', usersRoutes)
 app.use('/api/tickets', ticketsRoutes)
 app.use('/api/attachments', attachmentsRoutes)
+app.use('/api/requesters', requestersRoutes)
 
 export default app

--- a/server/src/controllers/requesters.controller.ts
+++ b/server/src/controllers/requesters.controller.ts
@@ -1,0 +1,14 @@
+import type { RequestHandler } from 'express'
+import prisma from '../db'
+
+// Public (no auth) - backs the Development Requester Selector, which by
+// design runs before the user has signed in. Only exposes id/fullName/email
+// for active Requester accounts; never passwordHash or any other field.
+export const listActiveRequesters: RequestHandler = async (_req, res) => {
+  const requesters = await prisma.user.findMany({
+    where: { role: 'REQUESTER', isActive: true },
+    orderBy: { fullName: 'asc' },
+    select: { id: true, fullName: true, email: true },
+  })
+  res.status(200).json(requesters)
+}

--- a/server/src/routes/requesters.routes.ts
+++ b/server/src/routes/requesters.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express'
+import { listActiveRequesters } from '../controllers/requesters.controller'
+
+const router = Router()
+
+router.get('/', listActiveRequesters)
+
+export default router

--- a/server/tests/full-app/requesters.test.ts
+++ b/server/tests/full-app/requesters.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import app from '../../src/app'
+
+describe('GET /api/requesters', () => {
+  it('is public - no Authorization header required', async () => {
+    const response = await request(app).get('/api/requesters')
+    expect(response.status).toBe(200)
+  })
+
+  it('returns only active Requester accounts, excluding the seeded inactive one', async () => {
+    const response = await request(app).get('/api/requesters')
+    expect(response.status).toBe(200)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body.some((r: { email: string }) => r.email === 'requester@toktickit.dev')).toBe(true)
+    expect(response.body.every((r: { email: string }) => r.email !== 'inactive-requester@toktickit.dev')).toBe(true)
+  })
+
+  it('never exposes a password or passwordHash field', async () => {
+    const response = await request(app).get('/api/requesters')
+    for (const requester of response.body) {
+      expect(requester).not.toHaveProperty('password')
+      expect(requester).not.toHaveProperty('passwordHash')
+      expect(Object.keys(requester).sort()).toEqual(['email', 'fullName', 'id'])
+    }
+  })
+
+  it('excludes IT Staff and Administrator accounts', async () => {
+    const response = await request(app).get('/api/requesters')
+    expect(response.body.some((r: { email: string }) => r.email === 'itstaff@toktickit.dev')).toBe(false)
+    expect(response.body.some((r: { email: string }) => r.email === 'admin@toktickit.dev')).toBe(false)
+  })
+})


### PR DESCRIPTION
﻿## Summary
Addresses the review comment on #35: adds a real Development Requester Selection screen (labsheet Section 8.1), which was missing since this app uses real auth instead. Not a fake mockup and not an auth bypass - it's a UI convenience over the app's existing real login:

- **New:** `GET /api/requesters` (public, no auth) - the "retrieve active Development Requesters" capability the labsheet's REST contract (Section 6) requires, which was entirely missing from the API. Returns only `{id, fullName, email}` for active Requester accounts.
- **New:** `/dev-requester-select` page - dropdown of active Requesters, Continue signs in via the real `POST /api/auth/login` using that seeded account's known password (seed credentials are already public in this repo). Accounts without a known seed password are shown but not auto-selectable, with a note pointing to the real Login page.
- Linked from Login ("Testing as a Requester? Use the Development Requester Selector") and from a new "Change Requester" navbar button (Requester role only).

## Bug found and fixed during testing
Clicking "Change Requester" intermittently landed on `/login` instead of the selector - a race between `logout()`'s state update and `ProtectedRoute`'s own redirect-on-logged-out check beating the explicit `navigate()` call. Fixed with `flushSync` around `logout()`.

## Testing
- `npm test --prefix server`: 8 files, 57 tests passing
- `npm test --prefix client`: 5 files, 19 tests passing
- `npm run build` passes on both
- Full Playwright walkthrough (Login -> selector link -> disabled-Continue note for an unknown-password account -> real sign-in via the known seed account -> themed dashboard -> Change Requester back to the selector) - no console errors

Base is `lab2-staging` (same as the rest of the Lab 2 PRs).
